### PR TITLE
configuration of monitoring; adding mirror ports - with errors.

### DIFF
--- a/app/client/cli/root.go
+++ b/app/client/cli/root.go
@@ -98,7 +98,7 @@ func NewClient() (*Client, error) {
 	host := os.Getenv("DEFAT_HOST")
 	//todo i have change it for testing purpose
 	if host == "" {
-		host = "grpc.mrturkmen.com"
+		host = "sec03.lab.es.aau.dk"
 	}
 
 	port := os.Getenv("DEFAT_PORT")

--- a/app/daemon/daemon.go
+++ b/app/daemon/daemon.go
@@ -128,7 +128,7 @@ func (d *daemon) Run() error {
 	if err != nil {
 		return &MngtPortErr{gRPCPort}
 	}
-	log.Info().Msgf("gRPC daemon has been started  ! on port : %d", gRPCPort)
+	log.Info().Msgf("gRPC daemon has been started  ! on port : %s", gRPCPort)
 
 	opts, err := d.grpcOpts()
 	if err != nil {

--- a/app/daemon/daemon.go
+++ b/app/daemon/daemon.go
@@ -128,7 +128,7 @@ func (d *daemon) Run() error {
 	if err != nil {
 		return &MngtPortErr{gRPCPort}
 	}
-	log.Info().Msg("gRPC daemon has been started  ! on port :5454")
+	log.Info().Msgf("gRPC daemon has been started  ! on port : %d", gRPCPort)
 
 	opts, err := d.grpcOpts()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 
 type VmConfig struct {
 	OvaDir string `yaml:"ova-dir"`
+	//OvaDir string `yaml:"ova-test"` //use for local test
 }
 
 type DefattConf struct {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -96,6 +96,7 @@ func New(options ...OptionFunc) *NetController {
 		flags:    make([]string, 0),
 		execFunc: shellExec,
 		debug:    true,
+		sudo:     true,
 		pipeFunc: shellPipe,
 	}
 	for _, o := range options {

--- a/dnet/dhcp/dhcp.go
+++ b/dnet/dhcp/dhcp.go
@@ -82,7 +82,7 @@ func addToSwitch(c *controller.NetController, net Subnet, bridge, cid string) er
 	return nil
 }
 
-func GenerateMac() net.HardwareAddr {
+func generateMac() net.HardwareAddr {
 	buf := make([]byte, 6)
 	var mac net.HardwareAddr
 
@@ -113,11 +113,11 @@ func New(ctx context.Context, ifaces map[string]string, bridge string, c *contro
 	ipPool := controller.NewIPPoolFromHost()
 	var sNet Subnet
 
-	var macAddress net.HardwareAddr
-	macAddress = GenerateMac()
-
+	//var macAddress net.HardwareAddr
+	macAddress := generateMac()
+	//macAddressString := string(macAddress)
 	macAddressString := stringHardwareAddress(macAddress)
-
+	//
 	for vl, vt := range ifaces {
 
 		//make and if and Else Here and put
@@ -240,4 +240,8 @@ func (dhcp *Server) Close() error {
 // might require mutex when using with goroutines
 func (dhcp *Server) GetVlanIP(vlan string) string {
 	return dhcp.ipList[vlan]
+}
+
+func (dhcp *Server) GetMAC() string {
+	return dhcp.macAddress
 }

--- a/game/environment.go
+++ b/game/environment.go
@@ -187,7 +187,7 @@ func (g *environment) StartGame(tag, name string, scenarioNo int) error {
 	log.Info().Msgf("Setting openvswitch bridge %s", bridgeName)
 	if err := g.initializeOVSBridge(bridgeName); err != nil {
 		log.Error().Err(err).Msg("Error with initializing OVSBridge")
-		//return err
+		return err
 	}
 	if err := g.createRandomNetworks(bridgeName, int(numNetworks)); err != nil {
 		log.Error().Err(err).Msgf("Error on creating random networks")
@@ -196,10 +196,12 @@ func (g *environment) StartGame(tag, name string, scenarioNo int) error {
 
 	if err := g.configureMonitor(bridgeName, numNetworks); err != nil {
 		log.Error().Err(err).Msgf("Error to configure monitoring")
+		return nil
 	}
 
 	if err := g.initializeScenarios(bridgeName, &g.controller, scenarioNo); err != nil {
 		log.Error().Err(err).Msgf("Error on initializing scenarios")
+		return nil
 	}
 
 	return nil
@@ -390,9 +392,8 @@ func (g *environment) configureMonitor(bridge string, numberNetworks int) error 
 
 	getBlue = "blueMirror"
 	if err := g.controller.Ovs.VSwitch.CreateMirrorforBridge(getBlue, bridge); err != nil {
-
-		fmt.Printf("Aparent nu ia numele: %s \n\n\n", getBlue)
 		log.Error().Err(err).Msgf("Error on creating mirror")
+		return err
 
 	}
 
@@ -427,6 +428,7 @@ func (g *environment) configureMonitor(bridge string, numberNetworks int) error 
 	portUUID, err := g.controller.Ovs.VSwitch.GetPortUUID(bluePort)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error on getting port uuid")
+		return err
 	}
 
 	if err := g.controller.Ovs.VSwitch.MirrorAllVlans(getBlue, portUUID, vlanTags); err != nil {
@@ -465,6 +467,7 @@ func (g *environment) configureMonitor(bridge string, numberNetworks int) error 
 	}
 
 	if err := g.initializeSOC(ifaces); err != nil {
+		log.Error().Err(err).Msgf("error starting VM with given interfaces")
 		return err
 	}
 

--- a/game/environment.go
+++ b/game/environment.go
@@ -336,10 +336,10 @@ func (g *environment) attachChallenge(bridge string, challengeList []string, cli
 			return err
 		}
 
-		if err := cli.Ovs.Docker.SetVlan(bridge, "eth0", cid, vlan); err != nil {
-			log.Error().Msgf("Error on ovs-docker SetVlan %v", err)
-			return err
-		}
+		//if err := cli.Ovs.Docker.SetVlan(bridge, "eth0", cid, vlan); err != nil {
+		//	log.Error().Msgf("Error on ovs-docker SetVlan %v", err)
+		//	return err
+		//}
 
 	}
 
@@ -354,8 +354,8 @@ func (g *environment) initializeScenarios(bridge string, cli *controller.NetCont
 	if scenarioNumber > 3 || scenarioNumber < 0 {
 		return fmt.Errorf("Invalid senario selection, make a selection between 1 to 3 ")
 	}
-	for _, net := range networks {
-		vlans = append(vlans, net.Vlan)
+	for _, nt := range networks {
+		vlans = append(vlans, nt.Vlan)
 
 	}
 	log.Debug().Strs("Network Vlans", vlans).Msgf("Vlans")
@@ -369,12 +369,11 @@ func (g *environment) initializeScenarios(bridge string, cli *controller.NetCont
 	// initializing SOC
 
 	// initializing scenarios by attaching correct challenge to correct network
-	for _, net := range networks {
-		if err := g.attachChallenge(bridge, net.Chals, cli, net.Vlan[len(net.Vlan)-2:]); err != nil {
+	for _, nt := range networks {
+		if err := g.attachChallenge(bridge, nt.Chals, cli, nt.Vlan[len(nt.Vlan)-2:]); err != nil {
 
 			fmt.Printf("Error in attach challenge %v", err)
 			return err
-
 		}
 
 	}
@@ -524,6 +523,8 @@ func (env *environment) initializeWireguard(networks []string) error {
 	}
 	if vm != nil {
 
+		//log.Debug().Msgf("VM needs to be started now.. ", vm.Info().Id)
+
 		log.Debug().Msgf("VM [ %s ] is starting .... ", vm.Info().Id)
 
 		if err := vm.Start(context.Background()); err != nil {
@@ -534,7 +535,8 @@ func (env *environment) initializeWireguard(networks []string) error {
 	return nil
 }
 
-func (env *environment) initializeSOC(networks []string) error {
+func (env *environment) initializeSOC(networks []string, mac string, nic int) error {
+
 	log.Debug().Str("Elastic Port", "9200").
 		Str("Kibana Port", "5601").
 		Msgf("Initalizing SoC for the game")
@@ -564,6 +566,9 @@ func (env *environment) initializeSOC(networks []string) error {
 		return err
 	}
 	if vm != nil {
+
+		//log.Debug().Msgf("VM needs to be started now.. ", vm.Info().Id)
+
 		log.Debug().Msgf("VM [ %s ] is starting .... ", vm.Info().Id)
 
 		if err := vm.Start(context.Background()); err != nil {
@@ -572,4 +577,5 @@ func (env *environment) initializeSOC(networks []string) error {
 		}
 	}
 	return nil
+
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aau-network-security/defat
 go 1.15
 
 require (
-	github.com/aau-network-security/openvswitch v0.0.0-20201127012516-ac88c4428854
+	github.com/aau-network-security/openvswitch v0.0.0-20210515183826-906eb8da3f05
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsouza/go-dockerclient v1.6.5
 	github.com/golang/protobuf v1.4.2
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20210421221651-33663a62ff08 // indirect
 	google.golang.org/grpc v1.28.0
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -4,30 +4,30 @@
 # todo: will be modified with more dynamic way of cleaning stuff
 
 #request sudo....
-if [[ $UID != 0 ]]; then
-    echo "Please run this script with sudo:"
-    echo "sudo $0 $*"
-    exit 1
-fi
+#if [[ $UID != 0 ]]; then
+#    echo "Please run this script with sudo:"
+#    echo "sudo $0 $*"
+#    exit 1
+#fi
 
-ovs-vsctl del-br game
-ip tuntap del tap0 mode tap
-ip tuntap del tap1 mode tap
-ip tuntap del tap2 mode tap
-ip tuntap del tap3 mode tap
-ip tuntap del tap4 mode tap
-ip tuntap del vlan10 mode tap
-ip tuntap del vlan20 mode tap
-ip tuntap del vlan30 mode tap
-
-
+sudo ovs-vsctl del-br game
+sudo ip tuntap del tap0 mode tap
+sudo ip tuntap del tap1 mode tap
+sudo ip tuntap del tap2 mode tap
+sudo ip tuntap del tap3 mode tap
+sudo ip tuntap del tap4 mode tap
+sudo ip tuntap del vlan10 mode tap
+sudo ip tuntap del vlan20 mode tap
+sudo ip tuntap del vlan30 mode tap
+sudo ip tuntap del mon10 mode tap
+sudo ip tuntap del ALLblue mode tap
 
 
 VBoxManage list runningvms | awk '/nap/ {print $1}' | xargs -I vmid VBoxManage controlvm vmid poweroff
 VBoxManage list vms | awk '/nap/ {print}' | xargs -I vmid VBoxManage unregistervm --delete vmid
 
 
-rm -rf /root/VirtualBox\ VMs/nap*
+rm -rf ~/VirtualBox\ VMs/nap
 
 #while read -r line; do
  #   vm=$(echo $line | cut -d ' ' -f 2)

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -24,7 +24,7 @@ sudo ip tuntap del ALLblue mode tap
 
 
 VBoxManage list runningvms | awk '/nap/ {print $1}' | xargs -I vmid VBoxManage controlvm vmid poweroff
-VBoxManage list vms | awk '/nap/ {print}' | xargs -I vmid VBoxManage unregistervm --delete vmid
+VBoxManage list vms | awk '/nap/ {print $2}' | xargs -I vmid VBoxManage unregistervm --delete vmid
 
 
 rm -rf ~/VirtualBox\ VMs/nap
@@ -41,15 +41,15 @@ rm -rf ~/VirtualBox\ VMs/nap
 # Remove all docker containers that have a UUID as name
 #docker ps -a --format '{{.Names}}' | grep -E '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | xargs docker rm -f
 
-docker kill $(docker ps -q -a --filter "label=nap")
+docker kill $(docker ps -q -a -f "label=nap")
 
-docker rm $(docker ps -q -a --filter "label=nap")
+docker rm $(docker ps -q -a -f "label=nap")
 
 
 
 
 # Remove all macvlan networks
-docker network rm $(docker network ls -q -f --filter "label=defatt")
+docker network rm $(docker network ls -q -f "label=defatt")
 
 # Prune entire docker
 docker system prune --filter "label=nap"

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -249,23 +249,6 @@ func SetBridge(nics []string, cleanFirst bool) VMOpt {
 	}
 }
 
-
-//func SetNameofVM() VMOpt {
-//	//var vmName = ""
-//	return func(ctx context.Context, vm *vm) (error) {
-//
-//		_, err := VBoxCmdContext(ctx, vboxModVM, vm.id, "--name", fmt.Sprintf("nap-%s", vm.id[:8]))
-//		if err != nil {
-//			return err
-//		}
-//		return nil
-//	}
-//
-//}
-
-
-
-
 func enableProsmiscMode(ctx context.Context, vmID string, nic int) error {
 	_, err := VBoxCmdContext(ctx, vboxModVM, vmID, fmt.Sprintf("--nicpromisc%d", nic), "allow-all")
 	if err != nil {
@@ -273,11 +256,6 @@ func enableProsmiscMode(ctx context.Context, vmID string, nic int) error {
 	}
 	return nil
 }
-
-
-
-
-
 
 // Tested
 // note that  --natpf1  is not supported on Vbox 6+
@@ -372,7 +350,7 @@ func (vm *vm) Snapshot(name string) error {
 
 func (v *vm) LinkedClone(ctx context.Context, snapshot string, vmOpts ...VMOpt) (VM, error) {
 	newID := strings.Replace(uuid.New().String(), "-", "", -1)
-	newID = fmt.Sprintf("nap-%s",newID)
+	newID = fmt.Sprintf("nap-%s", newID)
 	_, err := VBoxCmdContext(ctx, "clonevm", v.id, "--snapshot", snapshot, "--options", "link", "--name", newID, "--register")
 	if err != nil {
 		return nil, err

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -91,7 +91,7 @@ func NewVMWithSum(path, image string, checksum string, vmOpts ...VMOpt) VM {
 		path:  path,
 		image: image,
 		opts:  vmOpts,
-		id:    fmt.Sprintf("nap-%s{%s}", image, checksum),
+		id:    fmt.Sprintf("nap-%s%s", image, checksum),
 	}
 }
 
@@ -318,6 +318,14 @@ func SetCPU(cores uint) VMOpt {
 func SetRAM(mb uint) VMOpt {
 	return func(ctx context.Context, vm *vm) error {
 		_, err := VBoxCmdContext(ctx, vboxModVM, vm.id, "--memory", fmt.Sprintf("%d", mb))
+		return err
+	}
+}
+
+func SetMAC(macaddr string, nic int) VMOpt {
+	return func(ctx context.Context, vm *vm) error {
+		//_, err := VBoxCmdContext(ctx, vboxModVM, vm.id, fmt.Sprintf("--macaddress%s", nic), macaddr)
+		_, err := VBoxCmdContext(ctx, vboxModVM, vm.id, "--macaddress3", macaddr)
 		return err
 	}
 }


### PR DESCRIPTION
There is an error in the function that is creating the mirroring ports. 

To be fixed later. 

```
2021/05/15 14:20:27 ovs: exec: sudo [ovs-vsctl --may-exist add-port game getALLblue]
2021/05/15 14:20:27 ovs: exec: "ovs-vsctl: Error detected while setting up 'getALLblue': could not open network device getALLblue (No such device).  See ovs-vswitchd log for details.\novs-vsctl: The default log directory is \"/var/log/openvswitch\"."
2:20PM INF AddPort for mirroring Set Interface Options getALLblue
2021/05/15 14:20:27 ovs: exec: sudo [ovs-vsctl set interface getALLblue type=internal]
2021/05/15 14:20:27 ovs: exec: ""
2021/05/15 14:20:27 ovs: exec: sudo [ovs-vsctl --id=@getALLblue get port getALLblue -- set mirror blueMirror select_all=true select_vlan=10,20,30 output-port=@getALLblue]
2021/05/15 14:20:27 ovs: exec: "ovs-vsctl: unknown command 'get port'; use --help for help"
2:20PM ERR Error on adding port to mirror traffic error="exit status 1: ovs-vsctl: unknown command 'get port'; use --help for help"
2:20PM ERR Error to configure monitoring error="exit status 1: ovs-vsctl: unknown command 'get port'; use --help for help"
```
