### PR TITLE
Hotfix/add random ip generate wg interface #000

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -25,6 +25,10 @@ type NetController struct {
 	// Ovs Client
 	Ovs *ovs.Client
 
+	// IpPool
+
+	IPPool *IPPool
+
 	// Used to enable root command
 	sudo bool
 

--- a/dnet/dhcp/dhcp.go
+++ b/dnet/dhcp/dhcp.go
@@ -84,6 +84,7 @@ func New(ctx context.Context, ifaces map[string]string, bridge string, c *contro
 	var networks Networks
 	ipPool := controller.NewIPPoolFromHost()
 	var sNet Subnet
+	c.IPPool = ipPool
 
 	for vl, vt := range ifaces {
 		randIP, _ := ipPool.Get()

--- a/game/environment.go
+++ b/game/environment.go
@@ -190,8 +190,6 @@ func (g *environment) StartGame(tag, name string, scenarioNo int) error {
 
 	numNetworks := len(selectedScenario.Networks)
 	log.Info().Msgf("Setting openvswitch bridge %s", bridgeName)
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(2)
 
 	if err := g.initializeOVSBridge(bridgeName); err != nil {
 		mainErr = err
@@ -441,25 +439,6 @@ func (env *environment) initWireguardVM(networks []string, min, max int) error {
 			MemoryMB: 2048},
 		vbox.MapVMPort([]virtual.NatPortSettings{
 			{
-				HostPort:    "9200",
-				GuestPort:   "9200",
-				ServiceName: "elasticsearch",
-				Protocol:    "tcp",
-			},
-			{
-				HostPort:    "5601",
-				GuestPort:   "5601",
-				ServiceName: "kibana",
-				Protocol:    "tcp",
-			},
-			{
-				// this is for gRPC service
-				HostPort:    "5353",
-				GuestPort:   "5353",
-				ServiceName: "wgservice",
-				Protocol:    "tcp",
-			},
-			{
 				HostPort:    "44444",
 				GuestPort:   "22",
 				ServiceName: "sshd",
@@ -492,6 +471,7 @@ func (env *environment) initWireguardVM(networks []string, min, max int) error {
 func (env *environment) initializeSOC(networks []string) error {
 	log.Debug().Str("Elastic Port", "9200").
 		Str("Kibana Port", "5601").
+		Str("Wireshark Port", "3000").
 		Msgf("Initalizing SoC for the game")
 	vm, err := env.vlib.GetCopy(context.Background(),
 		vbox.InstanceConfig{Image: "soc.ova",


### PR DESCRIPTION
- [x] Get random ip from ippool for initializing VPN endpoint for red and blue team
- [x] Port map given range of ports (-to be able to have different games-) with host
- [x] Initialize VPN Enpoints (red and blue team interfaces inside the machine)
- [x] Enable access with port mapping to VPN endpoints which are initialized inside NAP VM
- [x] Add some functions into goroutines 

![running-vpn-interface](https://user-images.githubusercontent.com/13614433/122839346-2a664580-d2f8-11eb-99b4-196b4fcf106b.png)
  